### PR TITLE
Update miniMD for Kokkos 3.0 promotion

### DIFF
--- a/kokkos/Makefile
+++ b/kokkos/Makefile
@@ -4,13 +4,15 @@ MPI_PATH =
 HAVE_MPI = yes
 
 #Set the path to Kokkos
-KOKKOS_PATH = /home/crtrott/kokkos
+KOKKOS_PATH = ${HOME}/kokkos
 #Set the Devices to compile for
 KOKKOS_DEVICES=OpenMP
 #Set the Architecture to compiler for
 KOKKOS_ARCH=SNB
 #Set third party library usage
 KOKKOS_USE_TPL=
+#Set KOKKOS options
+KOKKOS_OPTIONS=
 
 CXXFLAGS = -O3 -g 
 LINKFLAGS = 


### PR DESCRIPTION
No problems with this miniApp when deprecated code is disabled. Simply made a minor update to the existing Makefile.

Will later add a CMAKE build script (likely for all Kokkos-enable miniapps)