### PR TITLE
add XLC makefile

### DIFF
--- a/target/Makefile.xlc
+++ b/target/Makefile.xlc
@@ -1,0 +1,62 @@
+# Makefile for mpicxx compiler
+
+SHELL = /bin/sh
+CUDA_ROOT?=/usr/local/cuda
+# Default Options
+#
+SIMD = no
+
+#.IGNORE:
+
+# System-specific settings
+
+
+CC =		xlc++
+CCFLAGS =	-O3 -I $(srcdir)/MPI-Stubs/ -MD -g -qsmp=omp -qoffload -std=c++11
+LINK =		xlc++
+LINKFLAGS =	-O3 -g -qsmp=omp -qoffload
+USRLIB =	-L $(srcdir)/MPI-Stubs/ -lmpi_stubs
+SYSLIB =
+SIZE =		size
+
+ifeq ($(SIMD), yes)
+CCFLAGS += -DUSE_SIMD
+endif
+
+ifeq ($(RED_PREC), yes)
+CCFLAGS += -ffast-math
+LINKFLAGS += -ffast-math
+endif
+
+ifeq ($(PAD), 3)
+CCFLAGS += -DPAD=3
+LINKFLAGS += -DPAD=3
+endif
+
+ifeq ($(PAD), 4)
+CCFLAGS += -DPAD=4
+LINKFLAGS += -DPAD=4
+endif
+
+ifeq ($(DEBUG), yes)
+CCFLAGS += -g -debug inline-debug-info
+LINKFLAGS += -g -debug inline-debug-info
+endif
+
+ifeq ($(SP), yes)
+CCFLAGS += -DPRECISION=1
+LINKFLAGS += -DPRECISION=1
+else
+CCFLAGS += -DPRECISION=2
+LINKFLAGS += -DPRECISION=2
+endif
+
+ifeq ($(LIBRT),yes)
+CCFLAGS += -DPREC_TIMER
+USRLIB += -lrt
+endif
+
+ifeq ($(OFFLOAD), nvptx)
+CCFLAGS   += -qtgtarch=sm_70 -DUSE_OFFLOAD -DOFFLOAD_NVPTX -DMAX_TEAM_SIZE=64 -I$(CUDA_ROOT)/include
+LINKFLAGS += -qtgtarch=sm_70 -L$(CUDA_ROOT)/lib64 -lnvToolsExt
+endif


### PR DESCRIPTION
Tested against this compiler on POWER9+V100.
```
$ xlc++ -qversion=verbose
IBM XL C/C++ for Linux, V16.1.1 (Community Edition)
Version: 16.01.0001.0003
Driver Version: 16.1.1(C/C++) Level: 190404 ID: _RXbulUR3EemRhIlXaqgrRQ
C/C++ Front End Version: 16.1.1(C/C++) Level: 190404 ID: _5zS_JFEJEemRhYlXaqgrRQ
High-Level Optimizer Version: 16.1.1(C/C++) and 16.1.1(Fortran) Level: 190404 ID: _8qy2aFcMEemRholXaqgrRQ
Low-Level Optimizer Version: 16.1.1(C/C++) and 16.1.1(Fortran) Level: 190404 ID: _AO0twiBaEemAt6l22ZCkwQ
Intermediate Language Splitter Version: 16.1.1(C/C++) and 16.1.1(Fortran) Level 190404 ID: _YjjuMKTuEeitLMuu6VxByg
W-Code to LLVM-IR Translator: 16.1.1(C/C++) and 16.1.1(Fortran) Level 190404 ID: _k40U8k93EemRhYlXaqgrRQ
NVVM-IR to PTX Translator: 16.1.1(C/C++) and 16.1.1(Fortran) Level 190404 ID: _aZtcAtk6EeiLR71RxbOxBQ
/opt/ibm/xlC/16.1.1/bin/.orig/xlc++: note: XL C/C++ Community Edition is a no-charge product and does not include official IBM support. You can provide feedback at the XL on POWER C/C++ Community Edition forum (http://ibm.biz/xlcpp-linux-ce). For information about a fully supported XL C/C++ compiler, visit XL C/C++ for Linux (http://ibm.biz/xlcpp-linux).
```
Signed-off-by: Jeff Hammond <jeff.r.hammond@intel.com>