### PR TITLE
Update omp_set_num_threads to void

### DIFF
--- a/target/openmp.h
+++ b/target/openmp.h
@@ -39,10 +39,10 @@ OpenMP wrapper for headerfile
 #ifdef _OPENMP
 #include <omp.h>
 #else
-inline int omp_get_thread_num() { return 0; }
-inline int omp_get_max_threads() { return 1; }
-inline int omp_set_num_threads(int num_threads) { return 1; }
-inline int __sync_fetch_and_add(int *ptr, int value)
+inline int  omp_get_thread_num() { return 0; }
+inline int  omp_get_max_threads() { return 1; }
+inline void omp_set_num_threads(int num_threads) { return 1; }
+inline int  __sync_fetch_and_add(int *ptr, int value)
 {
   int tmp = *ptr;
   ptr[0] += value;


### PR DESCRIPTION
OpenMP Spec says omp_set_num_threads(..) should be a void. This conflicts with some research toolchains.