### PR TITLE
fix target directory so that it can compile properly without linking in fopenmp

### DIFF
--- a/target/offload.h
+++ b/target/offload.h
@@ -34,7 +34,7 @@
 #include <cassert>
 #include <cstdio>
 #include <cstring>
-#include <omp.h>
+#include "openmp.h"
 #include "util.h"
 
 inline const char *get_variant_string()

--- a/target/openmp.h
+++ b/target/openmp.h
@@ -39,13 +39,23 @@ OpenMP wrapper for headerfile
 #ifdef _OPENMP
 #include <omp.h>
 #else
-inline int  omp_get_thread_num() { return 0; }
-inline int  omp_get_max_threads() { return 1; }
-inline void omp_set_num_threads(int num_threads) { return 1; }
-inline int  __sync_fetch_and_add(int *ptr, int value)
+
+#ifndef OPENMP_H
+#define OPENMP_H
+
+inline int omp_get_thread_num() { return 0; }
+inline int omp_get_max_threads() { return 1; }
+inline void omp_set_num_threads(int num_threads) { ; }
+inline int omp_get_num_teams(void) { return 1; }
+inline int omp_get_team_num(void) { return 0; }
+inline int omp_is_initial_device(void) { return 1; }
+inline int __sync_fetch_and_add(int *ptr, int value)
 {
   int tmp = *ptr;
   ptr[0] += value;
   return tmp;
 }
+
+#endif
+
 #endif

--- a/target/thermo.cpp
+++ b/target/thermo.cpp
@@ -37,7 +37,7 @@
 #include "stdio.h"
 #include "stdlib.h"
 #include "util.h"
-#include <omp.h>
+#include "openmp.h"
 
 Thermo::Thermo() {}
 Thermo::~Thermo() {}


### PR DESCRIPTION
change inclusion of omp.h in offload.h and thermo.h to openmp.h
add include guards to openmp.h stub functions
add omp_get_num_teams, omp_get_team_num, and omp_is_initial_device functions to stubs to ensure compilation