### PR TITLE
fix dumb copy-paste error

### DIFF
--- a/mpi-spec/comm.cpp
+++ b/mpi-spec/comm.cpp
@@ -331,9 +331,9 @@ void Comm::reverse_communicate(Atom &atom)
     if(sendproc[iswap] != me) {
 
       MPI_Datatype type = (sizeof(MMD_float) == 4) ? MPI_FLOAT : MPI_DOUBLE;
-      MPI_Send(buf_send.data(), reverse_send_size[iswap], type, recvproc[iswap], 0,
-               buf_recv.data(), reverse_recv_size[iswap], type, sendproc[iswap], 0,
-               MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+      MPI_Sendrecv(buf_send.data(), reverse_send_size[iswap], type, recvproc[iswap], 0,
+                   buf_recv.data(), reverse_recv_size[iswap], type, sendproc[iswap], 0,
+                   MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 
       buf = buf_recv;
     } else buf = buf_send;


### PR DESCRIPTION
MPI_Send should have been MPI_Sendrecv.  The MPI_Send arguments don't match and won't even compile.